### PR TITLE
Use different ideintifier for ruby from heroku one

### DIFF
--- a/support/PackageInfo.erb
+++ b/support/PackageInfo.erb
@@ -1,3 +1,3 @@
-<pkg-info format-version="2" identifier="org.ruby-lang.installer" version="<%= VERSION %>" install-location="/usr/local/td/ruby" auth="root">
+<pkg-info format-version="2" identifier="org.ruby-lang.installer.td" version="<%= VERSION %>" install-location="/usr/local/td/ruby" auth="root">
   <payload installKBytes="<%= kbytes %>" numberOfFiles="<%= num_files %>"/>
 </pkg-info>


### PR DESCRIPTION
Now, the identifier of ruby package for td is same as one for heroku because this repositoriy is a fork of ddollar/ruby-osx-packager (for heroku).
When td/heroku toolbelt is installed, old ruby with "org.ruby-lang.installer" is removed even if it is for td or heroku.
